### PR TITLE
Fix wrong print statement in __init__.py

### DIFF
--- a/lokey/__init__.py
+++ b/lokey/__init__.py
@@ -46,7 +46,7 @@ def cli(ctx, password):
     except Exception as e:
         raise click.ClickException(str(e))
     if not subcommand:
-        print ctx.obj.key
+        print(ctx.obj.key)
 
 
 @cli.group()


### PR DESCRIPTION
In function `cli(ctx, password)` there's a print statement (line 49) which is missing parentheses, resulting in error during runtime.

Here's the traceback:
```
Traceback (most recent call last):
  File "/home/dimitris/.local/bin/lokey", line 33, in <module>
    sys.exit(load_entry_point('lokey==0.5.0', 'console_scripts', 'lokey')())
  File "/home/dimitris/.local/bin/lokey", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 786, in exec_module
  File "<frozen importlib._bootstrap_external>", line 923, in get_code
  File "<frozen importlib._bootstrap_external>", line 853, in source_to_code
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/dimitris/.local/lib/python3.9/site-packages/lokey/__init__.py", line 49
    print ctx.obj.key
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(ctx.obj.key)?
```

I'm expressly granting permission for my fix to be licensed under the GPL. 